### PR TITLE
Fix #1 bug 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Franco-Poveda/logrus-splunk-hook
+
+go 1.14
+
+require github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/hook.go
+++ b/hook.go
@@ -20,10 +20,14 @@ func NewHook(client *Client, levels []logrus.Level) *Hook {
 
 // Fire triggers a splunk event
 func (h *Hook) Fire(entry *logrus.Entry) error {
-	prepEntry, _ := entry.String()
+	preparedEntry, err := entry.String()
 
-	err := h.Client.Log(
-		prepEntry,
+	if err != nil {
+		return err
+	}
+
+	err = h.Client.Log(
+		preparedEntry,
 	)
 	return err
 }

--- a/hook.go
+++ b/hook.go
@@ -20,8 +20,10 @@ func NewHook(client *Client, levels []logrus.Level) *Hook {
 
 // Fire triggers a splunk event
 func (h *Hook) Fire(entry *logrus.Entry) error {
+	prepEntry, _ := entry.String()
+
 	err := h.Client.Log(
-		entry,
+		prepEntry,
 	)
 	return err
 }

--- a/splunk.go
+++ b/splunk.go
@@ -12,12 +12,12 @@ import (
 
 // Event represents the log event object that is sent to Splunk when Client.Log is called.
 type Event struct {
-	Time       int64       `json:"time" binding:"required"`       // epoch time in seconds
-	Host       string      `json:"host" binding:"required"`       // hostname
-	Source     string      `json:"source" binding:"required"`     // app name
-	SourceType string      `json:"sourcetype" binding:"required"` // Splunk bucket to group logs in
-	Index      string      `json:"index" binding:"required"`      // idk what it does..
-	Event      interface{} `json:"event" binding:"required"`      // throw any useful key/val pairs here
+	Time       int64       `json:"time" binding:"required"`                 // epoch time in seconds
+	Host       string      `json:"host,omitempty" binding:"required"`       // hostname
+	Source     string      `json:"source,omitempty" binding:"required"`     // app name
+	SourceType string      `json:"sourcetype,omitempty" binding:"required"` // Splunk bucket to group logs in
+	Index      string      `json:"index,omitempty" binding:"required"`      // idk what it does..
+	Event      interface{} `json:"event" binding:"required"`                // throw any useful key/val pairs here
 }
 
 // Client manages communication with Splunk's HTTP Event Collector.


### PR DESCRIPTION
Fix bug mentioned in https://github.com/Franco-Poveda/logrus-splunk-hook/issues/1.

Current version of the hook is not working: it is passing *logrus.Entry as Event.Event - which can't be marshalled to JSON here (splunk.go:114): 
```go
func (c *Client) LogEvent(e *Event) error {
	// Convert requestBody struct to byte slice to prep for http.NewRequest
	b, err := json.Marshal(e)
	if err != nil {
		return err
	}
	return c.doRequest(bytes.NewBuffer(b))
}
```

